### PR TITLE
Version beta2

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main

--- a/.github/workflows/unit-tests-linux.yml
+++ b/.github/workflows/unit-tests-linux.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main

--- a/.github/workflows/unit-tests-windows.yml
+++ b/.github/workflows/unit-tests-windows.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -39,10 +39,8 @@ conda activate lussac
 # Install Lussac.
 pip install -e .[dev]
 
-# For the developmental version, you will likely need the latest developmental version of SpikeInterface
-git clone https://github.com/SpikeInterface/spikeinterface.git
-cd spikeinterface
-pip install -e .
+# To upgrade Lussac.
+git pull
 
 # If you want to check whether the installation was successful (optional)
 pytest

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,7 @@ It is recommended to install :code:`lussac` in an environment, such as conda:
 
 
 |:spider_web:| Installing from PyPi
-----------------------------------
+-----------------------------------
 
 You can install :code:`lussac` directly from PyPi using pip:
 

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -220,7 +220,7 @@ WIP
 
 
 The :code:`find_purkinje_cells` module
----------------------------------
+--------------------------------------
 
 | This module is only meant for cerebellar cortex recordings. It will link simple spikes and complex spikes coming from the same Purkinje cell, and set it as a property :code:`lussac_purkinje` (this property is automatically exported in the :code:`export_to_phy` module).
 | TODO: Explain how it works.
@@ -235,7 +235,7 @@ This module's parameters are:
 
 
 Example of finding Purkinje cells
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: json
 
@@ -280,11 +280,11 @@ Example of export to phy
 				"compute_pc_features": false,
 				"copy_binary": false,
 				"template_mode": "average",
-				'sparsity': {
+				"sparsity": {
 					"method": "radius",
 					"radius_um": 75.0
 				},
-				"verbose": False
+				"verbose": false
 			},
 			"estimate_contamination": {
 				"all": [0.3, 1.0]

--- a/docs/source/params.rst
+++ b/docs/source/params.rst
@@ -191,11 +191,12 @@ This :code:`dict` maps the analysis name to its location. For example:
 The :code:`lussac` section
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This section contains all the information needed for Lussac to know what to do with your data (i.e. post-processing and merging of multiple analyses). It is divided into 4 keys:
+This section contains all the information needed for Lussac to know what to do with your data (i.e. post-processing and merging of multiple analyses). It is divided into 5 keys:
 
 - :code:`logs_folder`: the path where to store the logs for Lussac (you will be able to inspect what Lussac did in this folder). If the directory doesn't exist, Lussac will create it. If the directory already exists and contains information about a previous run, Lussac will load this information (if a previous run crashed, Lussac will pick up where it left off).
 - :code:`tmp_folder`: the path to the temporary directory. To not load everything in memory, Lussac needs to write some information on the disk (preferentially a fast SSD rather than an HDD). The directory will be created by Lussac and removed at the end of the run.
 - :code:`si_global_job_kwargs`: some global keyword arguments for SpikeInterface (such as number of jobs, chunking ...). See example below.
+- :code:`overwrite_logs`: If :code:`true`, will delete the old logs (if they exist) and start from scratch (i.e. not loading from a previous run).
 - :code:`pipeline`: a dictionary containing what modules to run and in which order. See the next section below.
 
 

--- a/params_examples/params_cerebellar_cortex[beta].json
+++ b/params_examples/params_cerebellar_cortex[beta].json
@@ -70,6 +70,7 @@
 			"progress_bar": false,
 			"verbose": false
 		},
+		"overwrite_logs": false,
 		"pipeline": {
 			"units_categorization": {
 				"all": {

--- a/params_examples/params_cerebellar_cortex[beta].json
+++ b/params_examples/params_cerebellar_cortex[beta].json
@@ -99,9 +99,7 @@
 			"remove_bad_units_0": {  // Remove normal spikes from analyses dedicated to CS.
 				"spikes": {
 					"sortings": ["ks2_cs", "ks3_cs"],
-					"firing_rate": {
-						"max": 10.0
-					}
+					"all": {}
 				}
 			},
 			"remove_bad_units": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ dependencies = [
 	"tqdm>=4.64.0",
 	"requests>=2.28.0",
 	"overrides>=7.3.1",
-	"spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git",
-	"pytest>=7.1.3"
+	"spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git"
 ]
 
 [project.scripts]
@@ -32,9 +31,11 @@ lussac = "lussac.main:main"
 
 [project.optional-dependencies]
 dev = [
+	"pytest>=7.1.3",
+	"pytest-cov>=4.0.0",
 	"matplotlib",
 	"hdbscan>=0.8.33",  # 0.8.31/32 crash.
-	"pytest-cov>=4.0.0",
+	"zarr>=2.13.0",
 	"sphinx>=6.0",
 	"sphinxemoji>=0.2.0",
 	"sphinx-rtd-theme>=1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ lussac = "lussac.main:main"
 
 [project.optional-dependencies]
 dev = [
+	"spikeinterface@git+https://github.com/SpikeInterface/spikeinterface.git",
 	"pytest>=7.1.3",
 	"pytest-cov>=4.0.0",
 	"matplotlib",
@@ -79,5 +80,5 @@ testpaths = ["tests/"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["lussac"]
+include = ["lussac*"]
 namespaces = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["pip>=21.3", "setuptools>=65.6.3"]
 
 [project]
 name = "lussac"
-version = "2.0.0b2.dev"
+version = "2.0.0b2"
 authors = [
 	{name="Aurélien Wyngaard", email="aurelien.wyngaard@gmail.com"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["pip>=21.3", "setuptools>=65.6.3"]
 
 [project]
 name = "lussac"
-version = "2.0.0b1"
+version = "2.0.0b2.dev"
 authors = [
 	{name="Aurélien Wyngaard", email="aurelien.wyngaard@gmail.com"}
 ]
@@ -23,7 +23,7 @@ dependencies = [
 	"tqdm>=4.64.0",
 	"requests>=2.28.0",
 	"overrides>=7.3.1",
-	"spikeinterface>=0.98.2",
+	"spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git",
 	"pytest>=7.1.3"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
 	"matplotlib",
 	"hdbscan>=0.8.33",  # 0.8.31/32 crash.
 	"zarr>=2.13.0",
+	"wavpack-numcodecs>=0.1.2",
 	"sphinx>=6.0",
 	"sphinxemoji>=0.2.0",
 	"sphinx-rtd-theme>=1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ lussac = "lussac.main:main"
 dev = [
 	"pytest>=7.1.3",
 	"pytest-cov>=4.0.0",
-	"matplotlib",
 	"hdbscan>=0.8.33",  # 0.8.31/32 crash.
 	"zarr>=2.13.0",
 	"wavpack-numcodecs>=0.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ lussac = "lussac.main:main"
 dev = [
 	"pytest>=7.1.3",
 	"pytest-cov>=4.0.0",
+	"matplotlib",
 	"hdbscan>=0.8.33",  # 0.8.31/32 crash.
 	"zarr>=2.13.0",
 	"wavpack-numcodecs>=0.1.2",

--- a/src/lussac/core/lussac_data.py
+++ b/src/lussac/core/lussac_data.py
@@ -1,8 +1,9 @@
+import copy
 import logging
 import os
 import pathlib
+import shutil
 import sys
-import copy
 import tempfile
 from dataclasses import dataclass
 import numba
@@ -52,7 +53,7 @@ class LussacData:
 		params['lussac']['pipeline'] = self._format_params(params['lussac']['pipeline'])
 		self.params = params
 		self._tmp_directory = self._setup_tmp_directory(params['lussac']['tmp_folder'])
-		self._setup_logs_directory(params['lussac']['logs_folder'])
+		self._setup_logs_directory(params['lussac']['logs_folder'], params['lussac']['overwrite_logs'])
 
 		if 'si_global_job_kwargs' in params['lussac']:
 			si.set_global_job_kwargs(**params['lussac']['si_global_job_kwargs'])
@@ -263,13 +264,18 @@ class LussacData:
 		return tmp_dir
 
 	@staticmethod
-	def _setup_logs_directory(folder_path: str) -> None:
+	def _setup_logs_directory(folder_path: str, overwrite_logs: bool = False) -> None:
 		"""
 		Sets up the folder containing Lussac's logs.
 
 		@param folder_path: str
 			Path for the logs directory.
+		@param overwrite_logs: bool
+			If True, will erase the logs folder if it already exists.
 		"""
+
+		if overwrite_logs and os.path.exists(folder_path):
+			shutil.rmtree(folder_path)
 
 		os.makedirs(folder_path, exist_ok=True)
 

--- a/src/lussac/core/lussac_data.py
+++ b/src/lussac/core/lussac_data.py
@@ -147,8 +147,9 @@ class LussacData:
 			for unit_id in sorting.unit_ids:
 				spike_train = sorting.get_unit_spike_train(unit_id)
 				assert np.all(np.diff(spike_train) >= 0)
-				assert spike_train[0] >= 0
-				assert spike_train[-1] < self.recording.get_num_frames()
+				if len(spike_train) > 0:
+					assert spike_train[0] >= 0
+					assert spike_train[-1] < self.recording.get_num_frames()
 
 	@staticmethod
 	def _setup_probe(recording: si.BaseRecording, filename: str) -> si.BaseRecording:

--- a/src/lussac/core/template_extractor.py
+++ b/src/lussac/core/template_extractor.py
@@ -320,7 +320,7 @@ class TemplateExtractor:
 				spike_train = sorting.get_unit_spike_train(unit_id)
 				n_spikes = min(len(spike_train), self.params['max_spikes_per_unit'])
 				selected_spikes[unit_id] = np.sort(np.random.choice(spike_train, n_spikes, replace=False))
-			spike_vector = si.NumpySorting.from_dict(selected_spikes, self.sampling_frequency).to_spike_vector()
+			spike_vector = si.NumpySorting.from_unit_dict(selected_spikes, self.sampling_frequency).to_spike_vector()
 
 		(self.folder / "waveforms").mkdir(exist_ok=True, parents=True)
 		wvfs = si.extract_waveforms_to_buffers(recording, spike_vector, sorting.unit_ids, self.nbefore, 1 + self.nafter, mode="memmap",

--- a/src/lussac/modules/export_to_phy.py
+++ b/src/lussac/modules/export_to_phy.py
@@ -1,5 +1,6 @@
 import pathlib
 from typing import Any, Sequence
+import pandas as pd
 import numpy as np
 from overrides import override
 from lussac.core import LussacPipeline, MonoSortingModule
@@ -50,14 +51,18 @@ class ExportToPhy(MonoSortingModule):
 			params['export_params']['sparsity'] = si.compute_sparsity(wvf_extractor, **params['export_params']['sparsity'])
 
 		export_to_phy(wvf_extractor, output_folder, **params['export_params'])
+		new_unit_ids = pd.read_csv(output_folder / "cluster_si_unit_ids.tsv", delimiter='\t')
 
 		for property_name in self.sorting.get_property_keys():
 			if property_name.startswith('lussac_'):
-				self.write_tsv_file(output_folder / f"{property_name}.tsv", property_name, self.sorting.unit_ids, self.sorting.get_property(property_name))
+				unit_ids = new_unit_ids['si_unit_id'][np.argmax(new_unit_ids['cluster_id'].values == self.sorting.unit_ids[:, None], axis=1)].values
+				self.write_tsv_file(output_folder / f"{property_name}.tsv", property_name, unit_ids, self.sorting.get_property(property_name))
 
 		if 'estimate_contamination' in params:
 			estimated_cont = self._estimate_units_contamination(params['estimate_contamination'])
-			self.write_tsv_file(output_folder / "lussac_contamination.tsv", "lussac_cont (%)", list(estimated_cont.keys()), 100 * np.array(list(estimated_cont.values())))
+			unit_ids = np.array(list(estimated_cont.keys()))
+			unit_ids = new_unit_ids['si_unit_id'][np.argmax(new_unit_ids['cluster_id'].values == unit_ids[:, None], axis=1)].values
+			self.write_tsv_file(output_folder / "lussac_contamination.tsv", "lussac_cont (%)", unit_ids, 100 * np.array(list(estimated_cont.values())))
 
 		return self.sorting
 

--- a/src/lussac/modules/export_to_phy.py
+++ b/src/lussac/modules/export_to_phy.py
@@ -47,7 +47,7 @@ class ExportToPhy(MonoSortingModule):
 		wvf_extractor = self.extract_waveforms(**params['wvf_extraction'])
 		output_folder = pathlib.Path(self._format_output_path(params['path']))
 
-		if params['export_params']['sparsity'] is not None:
+		if 'sparsity' in params['export_params'] and params['export_params']['sparsity'] is not None:
 			params['export_params']['sparsity'] = si.compute_sparsity(wvf_extractor, **params['export_params']['sparsity'])
 
 		export_to_phy(wvf_extractor, output_folder, **params['export_params'])

--- a/src/lussac/modules/merge_sortings.py
+++ b/src/lussac/modules/merge_sortings.py
@@ -132,7 +132,7 @@ class MergeSortings(MultiSortingsModule):
 
 		similarity_matrices = {}
 		spike_vectors = {name: scur.remove_duplicated_spikes(sorting, censored_period).to_spike_vector() for name, sorting in self.sortings.items()}
-		n_spikes = {name: np.array(list(sorting.get_total_num_spikes().values())) for name, sorting in self.sortings.items()}
+		n_spikes = {name: np.array(list(sorting.count_num_spikes_per_unit().values())) for name, sorting in self.sortings.items()}
 
 		for name1, sorting1 in self.sortings.items():
 			similarity_matrices[name1] = {}
@@ -466,7 +466,7 @@ class MergeSortings(MultiSortingsModule):
 
 		logs.close()
 
-		sorting = si.NumpySorting.from_dict(new_spike_trains, self.sampling_f)
+		sorting = si.NumpySorting.from_unit_dict(new_spike_trains, self.sampling_f)
 		filename = f"{self.logs_folder}/merged_sorting.npz"
 		si.NpzSortingExtractor.write_sorting(sorting, filename)
 

--- a/src/lussac/modules/merge_units.py
+++ b/src/lussac/modules/merge_units.py
@@ -26,6 +26,7 @@ class MergeUnits(MonoSortingModule):
 				'ms_before': 1.0,
 				'ms_after': 1.5,
 				'max_spikes_per_unit': 2_000,
+				'sparse': False,
 				'filter': {
 					'band': [100, 9000],
 					'filter_order': 2,

--- a/tests/core/test_lussac_data.py
+++ b/tests/core/test_lussac_data.py
@@ -49,7 +49,7 @@ def test_sanity_check() -> None:
 	for name, sorting in sortings.items():
 		sorting.annotate(name=name if name != "wrong_name" else "uncorrect_name")
 
-	lussac_default_params = {'lussac': {'pipeline': {}, 'tmp_folder': "tests/tmp", 'logs_folder': "tests/tmp/logs"}}
+	lussac_default_params = {'lussac': {'pipeline': {}, 'tmp_folder': "tests/tmp", 'logs_folder': "tests/tmp/logs", 'overwrite_logs': False}}
 	LussacData(recording, {'correct': sortings['correct']}, lussac_default_params)
 
 	for name, sorting in sortings.items():
@@ -100,3 +100,5 @@ def test_logs(data: LussacData) -> None:
 	# TODO: Seems to not log when in pytest mode.
 	# with open(logs_file, 'r') as file:
 	# 	assert len(file.read()) > 2
+
+# TODO: Test 'overwrite_logs'.

--- a/tests/core/test_lussac_data.py
+++ b/tests/core/test_lussac_data.py
@@ -41,10 +41,10 @@ def test_sanity_check() -> None:
 	recording = recording.set_probe(probe)
 
 	sortings = {
-		'correct': si.NumpySorting.from_dict({0: np.array([0, 8, 7188, 29999]), 1: np.array([87, 9368, 21845])}, sampling_frequency=30000),
-		'wrong_sf': si.NumpySorting.from_dict({0: np.array([0, 8, 7188, 29999]), 1: np.array([87, 9368, 21845])}, sampling_frequency=10000),
-		'wrong_name': si.NumpySorting.from_dict({0: np.array([0, 8, 7188, 29999]), 1: np.array([87, 9368, 21845])}, sampling_frequency=30000),
-		'negative_st': si.NumpySorting.from_dict({0: np.array([0, 8, 7188, 29999]), 1: np.array([-87, 9368, 21845])}, sampling_frequency=30000)
+		'correct': si.NumpySorting.from_unit_dict({0: np.array([0, 8, 7188, 29999]), 1: np.array([87, 9368, 21845])}, sampling_frequency=30000),
+		'wrong_sf': si.NumpySorting.from_unit_dict({0: np.array([0, 8, 7188, 29999]), 1: np.array([87, 9368, 21845])}, sampling_frequency=10000),
+		'wrong_name': si.NumpySorting.from_unit_dict({0: np.array([0, 8, 7188, 29999]), 1: np.array([87, 9368, 21845])}, sampling_frequency=30000),
+		'negative_st': si.NumpySorting.from_unit_dict({0: np.array([0, 8, 7188, 29999]), 1: np.array([-87, 9368, 21845])}, sampling_frequency=30000)
 	}
 	for name, sorting in sortings.items():
 		sorting.annotate(name=name if name != "wrong_name" else "uncorrect_name")

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -149,9 +149,9 @@ def test_split_sorting(data: LussacData) -> None:
 
 
 def test_merge_sortings() -> None:
-	sorting1 = si.NumpySorting(30000, [0, 1, 3])
-	sorting2 = si.NumpySorting(30000, [5, 2, 9])
-	sorting3 = si.NumpySorting(30000, [1, 0, 6])
+	sorting1 = si.NumpySorting(np.array([]), 30000, [0, 1, 3])
+	sorting2 = si.NumpySorting(np.array([]), 30000, [5, 2, 9])
+	sorting3 = si.NumpySorting(np.array([]), 30000, [1, 0, 6])
 
 	sorting1.annotate(name="test")
 	sorting2.annotate(name="test")

--- a/tests/core/test_template_extractor.py
+++ b/tests/core/test_template_extractor.py
@@ -158,7 +158,7 @@ def test_get_units_best_channels(template_extractor: TemplateExtractor) -> None:
 
 
 def test_empty_units(template_extractor: TemplateExtractor) -> None:
-	sorting = si.NumpySorting.from_dict({}, 30_000)  # Make sure it doesn't crash with no units
+	sorting = si.NumpySorting.from_unit_dict({}, 30_000)  # Make sure it doesn't crash with no units
 	te = TemplateExtractor(template_extractor.recording, sorting, template_extractor.folder, template_extractor.params)
 	templates = te.get_templates(return_scaled=True)
 	assert templates.shape == (0, te.nsamples, te.num_channels)

--- a/tests/modules/test_align_units.py
+++ b/tests/modules/test_align_units.py
@@ -1,7 +1,8 @@
 import os
 import numpy as np
-from lussac.core import MonoSortingData
+from lussac.core import LussacData, MonoSortingData
 from lussac.modules import AlignUnits
+import spikeinterface.core as si
 
 
 params = {
@@ -31,6 +32,18 @@ def test_align_units(mono_sorting_data: MonoSortingData) -> None:
 	assert os.path.exists(f"{module.logs_folder}/alignment.html")
 
 	assert sorting.get_num_units() == data.sorting.get_num_units()
+
+
+def test_shift_sorting(data: LussacData) -> None:
+	sorting = si.NumpySorting.from_dict({0: np.array([5, data.recording.get_num_frames() - 5])}, sampling_frequency=data.recording.sampling_frequency)
+
+	new_sorting = AlignUnits.shift_sorting(data.recording, sorting, {0: 2})
+	assert new_sorting.get_num_units() == 1
+	assert np.all(new_sorting.get_unit_spike_train(0) == (3, data.recording.get_num_frames() - 7))
+
+	# Test that spikes over the edges are deleted.
+	assert AlignUnits.shift_sorting(data.recording, sorting, {0: 10}).get_num_units() == 1
+	assert AlignUnits.shift_sorting(data.recording, sorting, {0: -10}).get_num_units() == 1
 
 
 def test_get_units_shift() -> None:

--- a/tests/modules/test_align_units.py
+++ b/tests/modules/test_align_units.py
@@ -35,7 +35,7 @@ def test_align_units(mono_sorting_data: MonoSortingData) -> None:
 
 
 def test_shift_sorting(data: LussacData) -> None:
-	sorting = si.NumpySorting.from_dict({0: np.array([5, data.recording.get_num_frames() - 5])}, sampling_frequency=data.recording.sampling_frequency)
+	sorting = si.NumpySorting.from_unit_dict({0: np.array([5, data.recording.get_num_frames() - 5])}, sampling_frequency=data.recording.sampling_frequency)
 
 	new_sorting = AlignUnits.shift_sorting(data.recording, sorting, {0: 2})
 	assert new_sorting.get_num_units() == 1

--- a/tests/modules/test_export_to_phy.py
+++ b/tests/modules/test_export_to_phy.py
@@ -20,7 +20,8 @@ def test_export_multiple_sortings(pipeline: LussacPipeline) -> None:
 		'wvf_extraction': {
 			'ms_before': 1.0,
 			'ms_after': 2.0,
-			'max_spikes_per_unit': 10
+			'max_spikes_per_unit': 10,
+			'sparse': False
 		},
 		'export_params': {
 			'compute_pc_features': False,

--- a/tests/modules/test_export_to_phy.py
+++ b/tests/modules/test_export_to_phy.py
@@ -2,8 +2,9 @@ import copy
 import os
 import numpy as np
 import pandas as pd
-from lussac.core import LussacPipeline, MonoSortingData
+from lussac.core import LussacData, LussacPipeline, MonoSortingData
 from lussac.modules import ExportToPhy
+import spikeinterface.core as si
 
 
 def test_default_params(mono_sorting_data: MonoSortingData) -> None:
@@ -42,6 +43,12 @@ def test_export_multiple_sortings(pipeline: LussacPipeline) -> None:
 	assert os.path.exists(f"{folder}/ks2_best/spike_times.npy")
 	assert os.path.exists(f"{folder}/ms3_cs/spike_times.npy")
 	assert not os.path.exists(f"{folder}/ks2_cs/spike_times.npy")
+
+
+def test_empty_sorting(data: LussacData) -> None:
+	mono_sorting_data = MonoSortingData(data, si.NumpySorting.from_dict({}, sampling_frequency=30000))
+	module = ExportToPhy("test_etp_empty", mono_sorting_data, "all")
+	module.run(module.default_params)
 
 
 def test_format_output_path(mono_sorting_data: MonoSortingData) -> None:

--- a/tests/modules/test_export_to_phy.py
+++ b/tests/modules/test_export_to_phy.py
@@ -46,7 +46,7 @@ def test_export_multiple_sortings(pipeline: LussacPipeline) -> None:
 
 
 def test_empty_sorting(data: LussacData) -> None:
-	mono_sorting_data = MonoSortingData(data, si.NumpySorting.from_dict({}, sampling_frequency=30000))
+	mono_sorting_data = MonoSortingData(data, si.NumpySorting.from_unit_dict({}, sampling_frequency=30000))
 	module = ExportToPhy("test_etp_empty", mono_sorting_data, "all")
 	module.run(module.default_params)
 

--- a/tests/modules/test_merge_sortings.py
+++ b/tests/modules/test_merge_sortings.py
@@ -1,5 +1,4 @@
 import os
-import copy
 import pickle
 import pytest
 import networkx as nx
@@ -62,7 +61,12 @@ def test_compute_graph(data: LussacData) -> None:
 		}
 	}
 
-	graph = module._compute_graph(similarity_matrices, min_similarity=0.4, require_multi_sortings=False)
+	p = {
+		'similarity': {'min_similarity': 0.4},
+		'require_multiple_sortings_match': False
+	}
+
+	graph = module._compute_graph(similarity_matrices, p)
 	assert graph.number_of_nodes() == 8
 	assert graph.number_of_edges() == 6
 	assert graph.has_edge(('1', 0), ('2', 0))
@@ -74,9 +78,12 @@ def test_compute_graph(data: LussacData) -> None:
 		graph_loaded = pickle.load(file)
 		assert nx.is_isomorphic(graph, graph_loaded)
 
-	graph = module._compute_graph(similarity_matrices, min_similarity=0.4, require_multi_sortings=True)
+	p['require_multiple_sortings_match'] = True
+	graph = module._compute_graph(similarity_matrices, p)
 	assert graph.number_of_nodes() == 6  # Nodes not connected are removed.
 	assert graph.number_of_edges() == 6
+
+	# TODO: Test gt attributes.
 
 
 def test_graph(merge_sortings_module: MergeSortings) -> None:

--- a/tests/modules/test_merge_sortings.py
+++ b/tests/modules/test_merge_sortings.py
@@ -62,8 +62,7 @@ def test_compute_graph(data: LussacData) -> None:
 		}
 	}
 
-	graph = module._compute_graph(similarity_matrices, min_similarity=0.4)
-
+	graph = module._compute_graph(similarity_matrices, min_similarity=0.4, require_multi_sortings=False)
 	assert graph.number_of_nodes() == 8
 	assert graph.number_of_edges() == 6
 	assert graph.has_edge(('1', 0), ('2', 0))
@@ -74,6 +73,10 @@ def test_compute_graph(data: LussacData) -> None:
 	with open(f"{module.logs_folder}/similarity_graph.pkl", 'rb') as file:
 		graph_loaded = pickle.load(file)
 		assert nx.is_isomorphic(graph, graph_loaded)
+
+	graph = module._compute_graph(similarity_matrices, min_similarity=0.4, require_multi_sortings=True)
+	assert graph.number_of_nodes() == 6  # Nodes not connected are removed.
+	assert graph.number_of_edges() == 6
 
 
 def test_graph(merge_sortings_module: MergeSortings) -> None:

--- a/tests/modules/test_merge_sortings.py
+++ b/tests/modules/test_merge_sortings.py
@@ -40,9 +40,9 @@ def test_compute_similarity_matrices(merge_sortings_module: MergeSortings) -> No
 
 def test_compute_graph(data: LussacData) -> None:
 	sortings = {
-		'1': si.NumpySorting.from_dict({0: np.array([0]), 1: np.array([0]), 2: np.array([0])}, sampling_frequency=30000),
-		'2': si.NumpySorting.from_dict({0: np.array([0]), 1: np.array([0]), 2: np.array([0])}, sampling_frequency=30000),
-		'3': si.NumpySorting.from_dict({0: np.array([0]), 1: np.array([0])}, sampling_frequency=30000)
+		'1': si.NumpySorting.from_unit_dict({0: np.array([0]), 1: np.array([0]), 2: np.array([0])}, sampling_frequency=30000),
+		'2': si.NumpySorting.from_unit_dict({0: np.array([0]), 1: np.array([0]), 2: np.array([0])}, sampling_frequency=30000),
+		'3': si.NumpySorting.from_unit_dict({0: np.array([0]), 1: np.array([0])}, sampling_frequency=30000)
 	}
 	multi_sortings_data = MultiSortingsData(data, sortings)
 	module = MergeSortings("merge_sortings", multi_sortings_data, "all")

--- a/tests/modules/test_merge_units.py
+++ b/tests/modules/test_merge_units.py
@@ -3,6 +3,35 @@ from lussac.modules import MergeUnits
 from spikeinterface.core.testing import check_extractor_annotations_equal
 
 
+def test_remove_splits(mono_sorting_data: MonoSortingData) -> None:
+	module = MergeUnits("test_mu_splits", mono_sorting_data, "all")
+	sorting = mono_sorting_data.sorting
+	params = module.update_params({})
+
+	extra_outputs = {'pairs_decreased_score': [(71, 81), (52, 62)]}
+	assert all(x in sorting.unit_ids for x in [52, 62, 71, 81])
+
+	sorting = module._remove_splits(sorting, extra_outputs, params)
+	assert 71 in sorting.unit_ids and 81 not in sorting.unit_ids
+	assert 52 in sorting.unit_ids and 62 not in sorting.unit_ids
+
+
+def test_inner_merge(mono_sorting_data: MonoSortingData) -> None:
+	module = MergeUnits("test_mu_merge", mono_sorting_data, "all")
+	sorting = mono_sorting_data.sorting
+	params = module.update_params({})
+
+	# 68, 69, 71, 78 are from the same cell, 52 is another cell, and 999 doesn't exist.
+	assert all(x in sorting.unit_ids for x in [52, 68, 69, 71, 78])
+	assert 999 not in sorting.unit_ids
+
+	result = module._merge(sorting, [(52, 68), (68, 69), (69, 71), (71, 78), (78, 999)], params)
+	assert 52 not in result.unit_ids and 999 not in result.unit_ids
+	assert sum([x in result.unit_ids for x in [68, 69, 71, 78]]) == 1  # Only 1 unit remains.
+
+	# TODO: Check spike train of merged unit.
+
+
 def test_merge_units(mono_sorting_data: MonoSortingData) -> None:
 	data = mono_sorting_data.data.clone()
 	data.sortings = {'ms3_best': data.sortings['ms3_best'].select_units([7, 14, 15, 18, 20, 22, 29, 31, 53, 55, 59, 66, 67, 68, 69, 70, 71, 78, 81])}
@@ -25,20 +54,3 @@ def test_merge_units(mono_sorting_data: MonoSortingData) -> None:
 	assert sum([x in sorting.unit_ids for x in big_split]) == 1  # Only one unit from the big split should remain.
 
 	assert 70 in sorting.unit_ids  # 70 is the complex spike of the big split: should be kept.
-
-
-def test_remove_splits(mono_sorting_data: MonoSortingData) -> None:
-	module = MergeUnits("test", mono_sorting_data, "all")
-	sorting = mono_sorting_data.sorting
-	params = module.update_params({})
-
-	extra_outputs = {'pairs_decreased_score': [(71, 81), (52, 62)]}
-	assert all(x in sorting.unit_ids for x in [52, 62, 71, 81])
-
-	sorting = module._remove_splits(sorting, extra_outputs, params)
-	assert 71 in sorting.unit_ids and 81 not in sorting.unit_ids
-	assert 52 in sorting.unit_ids and 62 not in sorting.unit_ids
-
-
-def test_inner_merge(mono_sorting_data: MonoSortingData) -> None:
-	pass  # TODO

--- a/tests/modules/test_remove_duplicated_spikes.py
+++ b/tests/modules/test_remove_duplicated_spikes.py
@@ -13,7 +13,7 @@ def test_default_params(mono_sorting_data: MonoSortingData) -> None:
 	assert np.all([len(sorting.get_unit_spike_train(unit_id)) <= n_spikes[i] for i, unit_id in enumerate(sorting.unit_ids)])
 
 	# Test with known result
-	sorting = si.NumpySorting.from_dict({0: np.array([200, 850, 851, 852, 936, 2587]), 1: np.array([250, 853, 1287])}, module.sampling_f)
+	sorting = si.NumpySorting.from_unit_dict({0: np.array([200, 850, 851, 852, 936, 2587]), 1: np.array([250, 853, 1287])}, module.sampling_f)
 	data = MonoSortingData(mono_sorting_data.data, sorting)
 	module = RemoveDuplicatedSpikes("test_rds_known", data, "all")
 	sorting = module.run({'censored_period': 0.3, 'method': "random"})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ import shutil
 from tqdm import tqdm
 import lussac.main
 from conftest import params_path
+import spikeinterface.core as si
 
 
 def test_dataset_exists(capsys):
@@ -14,7 +15,7 @@ def test_dataset_exists(capsys):
 			file_path = pathlib.Path(__file__).parent / "datasets" / "cerebellar_cortex.zip"
 			file_path.parent.mkdir(parents=True, exist_ok=True)
 
-			http_response = requests.get("https://zenodo.org/record/8171363/files/lussac2_cerebellar_cortex_dev.zip", stream=True)
+			http_response = requests.get("https://zenodo.org/record/8171929/files/lussac2_cerebellar_cortex_dev.zip", stream=True)
 			n_bytes = int(http_response.headers.get("content-length"))
 
 			with tqdm.wrapattr(open(file_path, 'wb'), "write", miniters=1, desc=f"Downloading {file_path.name}", total=n_bytes) as fout:
@@ -26,6 +27,11 @@ def test_dataset_exists(capsys):
 			shutil.unpack_archive(file_path, file_path.parent)
 			file_path.unlink()
 
+			zarr_folder = file_path.parent / "cerebellar_cortex" / "recording.zarr"
+			recording = si.ZarrRecordingExtractor(zarr_folder)
+			recording.save(format="binary", folder=zarr_folder.parent / "recording.bin", n_jobs=2, chunk_duration='2s')
+
+			print("")
 			print(pathlib.Path(__file__).relative_to(pathlib.Path(os.getcwd())), end=' ')  # To have a nice output in the console.
 
 	assert params_path.exists()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,7 +14,7 @@ def test_dataset_exists(capsys):
 			file_path = pathlib.Path(__file__).parent / "datasets" / "cerebellar_cortex.zip"
 			file_path.parent.mkdir(parents=True, exist_ok=True)
 
-			http_response = requests.get("https://zenodo.org/record/8158445/files/lussac2_cerebellar_cortex_dev.zip", stream=True)
+			http_response = requests.get("https://zenodo.org/record/8171363/files/lussac2_cerebellar_cortex_dev.zip", stream=True)
 			n_bytes = int(http_response.headers.get("content-length"))
 
 			with tqdm.wrapattr(open(file_path, 'wb'), "write", miniters=1, desc=f"Downloading {file_path.name}", total=n_bytes) as fout:

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -145,8 +145,8 @@ def test_estimate_cross_contamination() -> None:
 
 def test_compute_coincidence_matrix() -> None:
 	# Test with known result.
-	sorting1 = si.NumpySorting.from_dict({0: np.array([18, 163, 622, 1197]), 1: np.array([161, 300, 894])}, sampling_frequency=30000)
-	sorting2 = si.NumpySorting.from_dict({0: np.array([120, 298, 303, 628]), 1: np.array([84, 532, 1092])}, sampling_frequency=30000)
+	sorting1 = si.NumpySorting.from_unit_dict({0: np.array([18, 163, 622, 1197]), 1: np.array([161, 300, 894])}, sampling_frequency=30000)
+	sorting2 = si.NumpySorting.from_unit_dict({0: np.array([120, 298, 303, 628]), 1: np.array([84, 532, 1092])}, sampling_frequency=30000)
 	coincidence_matrix = utils.compute_coincidence_matrix_from_vector(sorting1.to_spike_vector(), sorting2.to_spike_vector(), 8)
 
 	assert coincidence_matrix[0, 0] == 1
@@ -161,8 +161,8 @@ def test_compute_coincidence_matrix() -> None:
 	n_spikes = int(round(t_max * f))
 	window = 5		# Number of samples.
 
-	sorting1 = si.NumpySorting.from_dict({unit_id: np.sort(np.random.randint(low=0, high=T, size=n_spikes)) for unit_id in range(3)}, sf)
-	sorting2 = si.NumpySorting.from_dict({unit_id: np.sort(np.random.randint(low=0, high=T, size=n_spikes)) for unit_id in range(3)}, sf)
+	sorting1 = si.NumpySorting.from_unit_dict({unit_id: np.sort(np.random.randint(low=0, high=T, size=n_spikes)) for unit_id in range(3)}, sf)
+	sorting2 = si.NumpySorting.from_unit_dict({unit_id: np.sort(np.random.randint(low=0, high=T, size=n_spikes)) for unit_id in range(3)}, sf)
 	coincidence_matrix = utils.compute_coincidence_matrix_from_vector(sorting1.to_spike_vector(), sorting2.to_spike_vector(), window)
 
 	mean = n_spikes**2 * (2*window + 1) / T
@@ -173,8 +173,8 @@ def test_compute_coincidence_matrix() -> None:
 	assert mean - 2*std < np.mean(coincidence_matrix) < mean + 2*std
 
 	# Test with cross-shift.
-	sorting1 = si.NumpySorting.from_dict({0: np.array([100, 200, 400])}, sampling_frequency=sf)
-	sorting2 = si.NumpySorting.from_dict({0: np.array([106, 206, 406])}, sampling_frequency=sf)
+	sorting1 = si.NumpySorting.from_unit_dict({0: np.array([100, 200, 400])}, sampling_frequency=sf)
+	sorting2 = si.NumpySorting.from_unit_dict({0: np.array([106, 206, 406])}, sampling_frequency=sf)
 	cross_shift = np.array([[-6]])
 
 	coincidence_matrix = utils.compute_coincidence_matrix_from_vector(sorting1.to_spike_vector(), sorting2.to_spike_vector(), 2, None)
@@ -187,10 +187,10 @@ def test_compute_coincidence_matrix() -> None:
 def test_compute_similarity_matrix() -> None:
 	# Test with known result.
 	window = 5
-	sorting1 = si.NumpySorting.from_dict({0: np.array([18, 163, 622, 1197]), 1: np.array([161, 300, 894])}, sampling_frequency=30000)
-	sorting2 = si.NumpySorting.from_dict({0: np.array([155, 304, 628]), 1: np.array([17, 164, 622])}, sampling_frequency=30000)
-	n_spikes1 = np.array(list(sorting1.get_total_num_spikes().values()))
-	n_spikes2 = np.array(list(sorting2.get_total_num_spikes().values()))
+	sorting1 = si.NumpySorting.from_unit_dict({0: np.array([18, 163, 622, 1197]), 1: np.array([161, 300, 894])}, sampling_frequency=30000)
+	sorting2 = si.NumpySorting.from_unit_dict({0: np.array([155, 304, 628]), 1: np.array([17, 164, 622])}, sampling_frequency=30000)
+	n_spikes1 = np.array(list(sorting1.count_num_spikes_per_unit().values()))
+	n_spikes2 = np.array(list(sorting2.count_num_spikes_per_unit().values()))
 
 	coincidence_matrix = utils.compute_coincidence_matrix_from_vector(sorting1.to_spike_vector(), sorting2.to_spike_vector(), window)
 	similarity_matrix = utils.compute_similarity_matrix(coincidence_matrix, n_spikes1, n_spikes2, window)
@@ -205,10 +205,10 @@ def test_compute_similarity_matrix() -> None:
 	n_spikes = int(round(t_max * f))
 	window = 5		# Number of samples.
 
-	sorting1 = si.NumpySorting.from_dict({unit_id: np.sort(np.random.randint(low=0, high=T, size=n_spikes)) for unit_id in range(3)}, sf)
-	sorting2 = si.NumpySorting.from_dict({unit_id: np.sort(np.random.randint(low=0, high=T, size=n_spikes)) for unit_id in range(3)}, sf)
-	n_spikes1 = np.array(list(sorting1.get_total_num_spikes().values()))
-	n_spikes2 = np.array(list(sorting2.get_total_num_spikes().values()))
+	sorting1 = si.NumpySorting.from_unit_dict({unit_id: np.sort(np.random.randint(low=0, high=T, size=n_spikes)) for unit_id in range(3)}, sf)
+	sorting2 = si.NumpySorting.from_unit_dict({unit_id: np.sort(np.random.randint(low=0, high=T, size=n_spikes)) for unit_id in range(3)}, sf)
+	n_spikes1 = np.array(list(sorting1.count_num_spikes_per_unit().values()))
+	n_spikes2 = np.array(list(sorting2.count_num_spikes_per_unit().values()))
 
 	coincidence_matrix = utils.compute_coincidence_matrix_from_vector(sorting1.to_spike_vector(), sorting2.to_spike_vector(), window)
 	similarity_matrix = utils.compute_similarity_matrix(coincidence_matrix, n_spikes1, n_spikes2)

--- a/tests/utils/test_plotting.py
+++ b/tests/utils/test_plotting.py
@@ -60,7 +60,7 @@ def test_plot_units(data: LussacData) -> None:
 	assert os.path.exists(f"{folder}/plot_units.html")
 	assert os.path.exists(f"{folder}/plot_units_all_channels.html")
 
-	empty_sorting = si.NumpySorting.from_dict({}, sampling_frequency=30000)
+	empty_sorting = si.NumpySorting.from_unit_dict({}, sampling_frequency=30000)
 	empty_wvf_extractor = si.extract_waveforms(data.recording, empty_sorting, mode="memory", allow_unfiltered=True)
 
 	utils.plot_units(empty_wvf_extractor, filepath=f"{folder}/plot_units_empty")
@@ -68,7 +68,7 @@ def test_plot_units(data: LussacData) -> None:
 
 
 def test_create_gt_annotations() -> None:
-	sorting = si.NumpySorting.from_dict({0: np.array([3, 60], dtype=np.int64), 1: np.array([90, 187, 601], dtype=np.int64)}, 30000)
+	sorting = si.NumpySorting.from_unit_dict({0: np.array([3, 60], dtype=np.int64), 1: np.array([90, 187, 601], dtype=np.int64)}, 30000)
 	assert len(utils.create_gt_annotations(sorting)) == 0
 
 	sorting.set_property(key="gt_label", values=['Good', 'Bad'])

--- a/tests/utils/test_plotting.py
+++ b/tests/utils/test_plotting.py
@@ -52,7 +52,7 @@ def test_plot_units(data: LussacData) -> None:
 	sorting = data.sortings['ks2_best'].select_units([13, 19, 40, 41])
 	sorting.set_property("gt_label", np.array([f"label{unit_id}" for unit_id in sorting.unit_ids]))
 	wvf_extractor = si.extract_waveforms(data.recording, sorting, folder="tests/tmp/plotting/wvf_extractor", ms_before=1.5, ms_after=2.5,
-										 max_spikes_per_unit=100, allow_unfiltered=True)
+										 max_spikes_per_unit=100, sparse=False, allow_unfiltered=True)
 
 	utils.plot_units(wvf_extractor, filepath=f"{folder}/plot_units", annotations_fix=[{'text': "I am a fixed annotation"}],
 					 annotations_change=[{'text': f"I am unit {unit_id}"} for unit_id in wvf_extractor.unit_ids])


### PR DESCRIPTION
Changelog:

- Reformating of several modules
- Compatibility with the newest SpikeInterface
- Fixed a crash with spikes going over the edge (#4)
- Added parameter `overwrite_logs` (#2)
- Test dataset (for `pytest`) is now lighter
- Fixed a crash while loading empty units
- Fixed a bug where the annotations of lussac in `export_to_phy` didn't correspond to the correct units
- Multiple improvements made to `merge_sortings`
- Hopefully fixes installation bugs (#5)