### PR TITLE
load the analyzer if folder already created

### DIFF
--- a/src/lussac/core/module.py
+++ b/src/lussac/core/module.py
@@ -115,7 +115,10 @@ class LussacModule(ABC):
 			recording = spre.gaussian_filter(recording, *filter_band, margin_sd=2)
 
 		sorting = sorting.to_numpy_sorting()  # Convert sorting for faster extraction.
-		return si.create_sorting_analyzer(sorting, recording, format="binary_folder", folder=folder_path, **params)
+		if pathlib.Path(folder_path).exists():
+			return si.load_sorting_analyzer(folder=folder_path)
+		else:
+			return si.create_sorting_analyzer(sorting, recording, format="binary_folder", folder=folder_path, **params)
 
 
 @dataclass(slots=True)
@@ -295,6 +298,7 @@ class MonoSortingModule(LussacModule):
 		sorting = self.sorting
 
 		filter_band = None if 'filter' not in params else params['filter']
+
 		analyzer = self.create_analyzer(sub_folder=attribute, filter_band=filter_band)
 
 		match attribute:


### PR DESCRIPTION
This stops the error I sent you via email.

Running spike-sorting algorithms:
Loading analysis 'ks2_default'
Loading analysis 'ks2_5_best'
Loading analysis 'ks2_cs'


**********************************
****** units_categorization ******
**********************************
Running category 'all':
        - Sorting  ks2_default       Traceback (most recent call last):
  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac.py", line 149, in <module>
    main(sys.argv[1:])  # Pass command-line arguments except the script name
    ^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac.py", line 134, in main
    launch_lussac(params, data)
  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac.py", line 67, in launch_lussac
    pipeline.launch()
  File "/home/bs/repositories/lussac/src/lussac/core/pipeline.py", line 60, in launch
    self._run_mono_sorting_module(module, module_key, category, params)
  File "/home/bs/repositories/lussac/src/lussac/core/pipeline.py", line 99, in _run_mono_sorting_module
    sub_sorting = module_instance.run(params0)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/modules/units_categorization.py", line 29, in run
    value = self.get_units_attribute_arr(attribute, p)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/core/module.py", line 354, in get_units_attribute_arr
    return np.array(list(self.get_units_attribute(attribute, params).values()))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/core/module.py", line 298, in get_units_attribute
    analyzer = self.create_analyzer(sub_folder=attribute, filter_band=filter_band)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/core/module.py", line 196, in create_analyzer
    return super(MonoSortingModule, self).create_analyzer(sorting, sub_folder, filter_band, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/core/module.py", line 118, in create_analyzer
    return si.create_sorting_analyzer(sorting, recording, format="binary_folder", folder=folder_path, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 114, in create_sorting_analyzer
    sorting_analyzer = SortingAnalyzer.create(sorting, recording, format=format, folder=folder, sparsity=sparsity)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 220, in create
    cls.create_binary_folder(folder, sorting, recording, sparsity, rec_attributes=None)
  File "/home/bs/repositories/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 287, in create_binary_folder
    raise ValueError(f"Folder already exists {folder}")
ValueError: Folder already exists /media/bs/tmp_working/86.230424_2023-09-21_g0/lussac2/tmp_ft_fwbyy/units_categorization/all/ks2_default/firing_rate