### PR TITLE
Skip empty sortings

### DIFF
--- a/src/lussac/core/module.py
+++ b/src/lussac/core/module.py
@@ -115,7 +115,10 @@ class LussacModule(ABC):
 			recording = spre.gaussian_filter(recording, *filter_band, margin_sd=2)
 
 		sorting = sorting.to_numpy_sorting()  # Convert sorting for faster extraction.
-		return si.create_sorting_analyzer(sorting, recording, format="binary_folder", folder=folder_path, **params)
+		if pathlib.Path(folder_path).exists():
+			return si.load_sorting_analyzer(folder=folder_path)
+		else:
+			return si.create_sorting_analyzer(sorting, recording, format="binary_folder", folder=folder_path, **params)
 
 
 @dataclass(slots=True)
@@ -295,6 +298,7 @@ class MonoSortingModule(LussacModule):
 		sorting = self.sorting
 
 		filter_band = None if 'filter' not in params else params['filter']
+
 		analyzer = self.create_analyzer(sub_folder=attribute, filter_band=filter_band)
 
 		match attribute:

--- a/src/lussac/core/module.py
+++ b/src/lussac/core/module.py
@@ -115,10 +115,7 @@ class LussacModule(ABC):
 			recording = spre.gaussian_filter(recording, *filter_band, margin_sd=2)
 
 		sorting = sorting.to_numpy_sorting()  # Convert sorting for faster extraction.
-		if pathlib.Path(folder_path).exists():
-			return si.load_sorting_analyzer(folder=folder_path)
-		else:
-			return si.create_sorting_analyzer(sorting, recording, format="binary_folder", folder=folder_path, **params)
+		return si.create_sorting_analyzer(sorting, recording, format="binary_folder", folder=folder_path, **params)
 
 
 @dataclass(slots=True)
@@ -298,7 +295,6 @@ class MonoSortingModule(LussacModule):
 		sorting = self.sorting
 
 		filter_band = None if 'filter' not in params else params['filter']
-
 		analyzer = self.create_analyzer(sub_folder=attribute, filter_band=filter_band)
 
 		match attribute:

--- a/src/lussac/core/pipeline.py
+++ b/src/lussac/core/pipeline.py
@@ -96,9 +96,10 @@ class LussacPipeline:
 			if 'sortings' in params0:
 				del params0['sortings']
 
-			sub_sorting = module_instance.run(params0)
+			if len(unit_ids) > 0:
+				sub_sorting = module_instance.run(params0)
 
-			self.data.sortings[name] = self.merge_sortings(sub_sorting, other_sorting)
+				self.data.sortings[name] = self.merge_sortings(sub_sorting, other_sorting)
 
 			t2 = time.perf_counter()
 			logging.info(f" (Done in {t2-t1:.1f} s)\n")

--- a/src/lussac/core/pipeline.py
+++ b/src/lussac/core/pipeline.py
@@ -83,10 +83,15 @@ class LussacPipeline:
 			if 'sortings' in params and name not in params['sortings']:
 				continue
 
-			logging.info(f"\t- Sorting  {name:<18}")
-			t1 = time.perf_counter()
-
 			unit_ids = self.get_unit_ids_for_category(category, sorting)
+
+			if len(unit_ids) == 0:
+				logging.info(f"\t- Sorting {name:<18} skipped (no units)")
+				continue
+
+			logging.info(f"\t- Sorting  {name:<18}")
+			
+			t1 = time.perf_counter()
 			sub_sorting, other_sorting = self.split_sorting(sorting, unit_ids)
 
 			data = MonoSortingData(self.data, sub_sorting)
@@ -96,10 +101,8 @@ class LussacPipeline:
 			if 'sortings' in params0:
 				del params0['sortings']
 
-			if len(unit_ids) > 0:
-				sub_sorting = module_instance.run(params0)
-
-				self.data.sortings[name] = self.merge_sortings(sub_sorting, other_sorting)
+			sub_sorting = module_instance.run(params0)
+			self.data.sortings[name] = self.merge_sortings(sub_sorting, other_sorting)
 
 			t2 = time.perf_counter()
 			logging.info(f" (Done in {t2-t1:.1f} s)\n")


### PR DESCRIPTION
SpikeInterface complains when there are no spikes:

**********************************   
******** remove_bad_units ********   
**********************************   
Running category 'rest':
        - Sorting  ks2_default        (Done in 69.5 s)
        - Sorting  ks2_5_best         (Done in 85.3 s)
        - Sorting  ks2_cs             (Done in 63.8 s)
Running category 'spikes':
        - Sorting  ks2_default        (Done in 1228.9 s)
        - Sorting  ks2_5_best         (Done in 1298.0 s)
        - Sorting  ks2_cs            Traceback (most recent call last):
  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac.py", line 149, in <module>
    main(sys.argv[1:])  # Pass command-line arguments except the script name
    ^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac.py", line 134, in main
    launch_lussac(params, data)
  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac.py", line 67, in launch_lussac
    pipeline.launch()
  File "/home/bs/repositories/lussac/src/lussac/core/pipeline.py", line 60, in launch
    self._run_mono_sorting_module(module, module_key, category, params)
  File "/home/bs/repositories/lussac/src/lussac/core/pipeline.py", line 99, in _run_mono_sorting_module
    sub_sorting = module_instance.run(params0)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/modules/remove_bad_units.py", line 31, in run
    value = self.get_units_attribute_arr(attribute, p)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/core/module.py", line 358, in get_units_attribute_arr
    return np.array(list(self.get_units_attribute(attribute, params).values()))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/core/module.py", line 302, in get_units_attribute
    analyzer = self.create_analyzer(sub_folder=attribute, filter_band=filter_band)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/core/module.py", line 199, in create_analyzer
    return super(MonoSortingModule, self).create_analyzer(sorting, sub_folder, filter_band, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/lussac/src/lussac/core/module.py", line 121, in create_analyzer
    return si.create_sorting_analyzer(sorting, recording, format="binary_folder", folder=folder_path, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 110, in create_sorting_analyzer
    sparsity = estimate_sparsity(recording, sorting, **sparsity_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/spikeinterface/src/spikeinterface/core/sparsity.py", line 605, in estimate_sparsity
    random_spikes_indices = random_spikes_selection(
                            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bs/repositories/spikeinterface/src/spikeinterface/core/sorting_tools.py", line 208, in random_spikes_selection
    random_spikes_indices = np.concatenate(random_spikes_indices)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<__array_function__ internals>", line 200, in concatenate
