### PR TITLE
Fix redundant node removal

### DIFF
--- a/src/lussac/modules/merge_sortings.py
+++ b/src/lussac/modules/merge_sortings.py
@@ -678,6 +678,8 @@ class MergeSortings(MultiSortingsModule):
 		for pair in pairs:
 			unit_id1 = sorting.unit_ids[pair[0]]
 			unit_id2 = sorting.unit_ids[pair[1]]
+			if not graph.has_node(unit_id1) or not graph.has_node(unit_id2):
+				continue
 
 			score1 = num_spikes[unit_id1] * (1 - (k+1)*contamination[unit_id1])
 			score2 = num_spikes[unit_id2] * (1 - (k+1)*contamination[unit_id2])
@@ -707,7 +709,8 @@ class MergeSortings(MultiSortingsModule):
 
 			for i, unit_id in enumerate(unit_ids):
 				if i != idx:
-					graph.remove_node(unit_id)
+					if graph.has_node(unit_id):
+						graph.remove_node(unit_id)
 
 		unit_ids = np.sort(list(graph.nodes))
 		return sorting.select_units(unit_ids)


### PR DESCRIPTION
This PR clears an error that showed up on one recording:

```
**********************************

********* merge_sortings *********

**********************************

Running category 'CS':

        Done in 2280.4 s

Running category 'spikes':

Traceback (most recent call last):

  File "/home/bs/.local/micromamba/envs/lussac2/lib/python3.12/site-packages/networkx/classes/graph.py", line 683, in remove_node

    nbrs = list(adj[n])  # list handles self-loops (allows mutation)

                ~~~^^^

KeyError: 299



The above exception was the direct cause of the following exception:



Traceback (most recent call last):

  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac/run_lussac.py", line 693, in <module>

    main(sys.argv[1:])  # Pass command-line arguments except the script name

    ^^^^^^^^^^^^^^^^^^

  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac/run_lussac.py", line 621, in main

    raise e

  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac/run_lussac.py", line 616, in main

    launch_lussac(params_file=params_file)

  File "/home/bs/repositories/pythonUtilities/neuropixels/run_lussac/run_lussac.py", line 62, in launch_lussac

    pipeline.launch()

  File "/home/bs/repositories/lussac/src/lussac/core/pipeline.py", line 65, in launch

    self._run_multi_sortings_module(module, module_key, module_params)

  File "/home/bs/repositories/lussac/src/lussac/core/pipeline.py", line 173, in _run_multi_sortings_module

    sub_sortings = module_instance.run(params)

                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/bs/repositories/lussac/src/lussac/modules/merge_sortings.py", line 95, in run

    merged_sorting = self.remove_redundant(merged_sorting, params)

                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/bs/repositories/lussac/src/lussac/modules/merge_sortings.py", line 688, in remove_redundant

    graph.remove_node(unit_id1)

  File "/home/bs/.local/micromamba/envs/lussac2/lib/python3.12/site-packages/networkx/classes/graph.py", line 686, in remove_node

    raise NetworkXError(f"The node {n} is not in the graph.") from err

networkx.exception.NetworkXError: The node 299 is not in the graph.
```